### PR TITLE
Support for ssl-public-endpoints plugin for 6.1

### DIFF
--- a/cleanup_cloud.sh
+++ b/cleanup_cloud.sh
@@ -5,7 +5,7 @@ source ${TOP_DIR}/helpers/init_env_variables.sh
 
 CONTROLLER_HOST="node-$(fuel node "$@" | grep controller | awk '{print $1}' | head -1)"
 TOKEN=$(ssh ${CONTROLLER_HOST} egrep "^admin_token.*" /etc/keystone/keystone.conf 2> /dev/null |cut -d'=' -f2)
-OS_AUTH_URL="http://$(remote_cli cat /etc/astute.yaml |grep public_vip|awk '{print $2}'):5000/v2.0"
+OS_AUTH_URL="$(ssh ${CONTROLLER_HOST} ". openrc; keystone catalog --service identity 2>/dev/null | grep publicURL | awk '{print \$4}'")"
 
 
 keystone_adm()

--- a/helpers/init_env_variables.sh
+++ b/helpers/init_env_variables.sh
@@ -21,6 +21,11 @@ KEYSTONE_HAPROXY_CONFIG_PATH="${KEYSTONE_HAPROXY_CONFIG_PATH:-/etc/haproxy/conf.
 default_tempest_commit_id="0f1b1b76cc5a0ced4e36941b394c7bd5ae8fc614"
 TEMPEST_COMMIT_ID="${TEMPEST_COMMIT_ID:-${default_tempest_commit_id}}"
 
+# SSL options
+REMOTE_CA_CERT="${REMOTE_CA_CERT:-/etc/haproxy/ca.pem}"
+LOCAL_CA_CERT="${LOCAL_CA_CERT:-${USER_HOME_DIR}/ca.pem}"
+SSL="${SSL:-}"
+
 # Helper functions
 message() {
     printf "\e[33m%s\e[0m\n" "${1}"

--- a/tempest/configure_tempest.sh
+++ b/tempest/configure_tempest.sh
@@ -94,6 +94,7 @@ tenant_name = demo
 username = demo
 uri = ${OS_AUTH_URL}
 uri_v3 = ${OS_AUTH_URL/v2.0/v3}
+ca_certificates_file=${OS_CACERT}
 
 [network]
 public_network_id = ${PUBLIC_NETWORK_ID}


### PR DESCRIPTION
- added CA certificate download from controller node
- updated HAProxy admin API bind
- set CA cert option in tempest.conf

Change-Id: I6dd571d0c2c57f35bd01c139c3e2bba2c14b9613